### PR TITLE
feat: 북마크 관련 Api 및 마이페이지, 유저페이지 기능 추가

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -28,8 +28,16 @@ const TABS = {
 };
 
 const MyPage = () => {
-  const [activeTab, setActiveTab] = useState(TABS.TICKET);
   const accessToken = Cookies.get("accessToken");
+
+  const [activeTab, setActiveTab] = useState(() => {
+    const savedTab = sessionStorage.getItem("activeTab");
+    return savedTab ? savedTab : TABS.TICKET;
+  });
+
+  useEffect(() => {
+    sessionStorage.setItem("activeTab", activeTab);
+  }, [activeTab]);
 
   const { data, error, isLoading, refetch } = useQuery({
     queryKey: ["member", accessToken],

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -55,13 +55,12 @@ const MyPage = () => {
     enabled: !!accessToken,
   });
 
-  const { data: totalBookmarkCount } = useQuery<number>(
-    "bookMarkCount",
-    fetchBookmarkCount,
-    { enabled: !!accessToken }
-  );
+  const { data: bookmarkCounts } = useQuery({
+    queryKey: ["bookmarkCounts"],
+    queryFn: fetchBookmarkCount,
+    enabled: !!accessToken,
+  });
 
-  console.log(totalBoardCount);
   if (isLoading) {
     return <div>Loading...</div>;
   }
@@ -71,13 +70,7 @@ const MyPage = () => {
   }
 
   const userData = data && data.result;
-  console.log("userData : ", userData);
   const member = userData?.memberId;
-
-  console.log(totalBoardCount);
-
-  console.log('totalBookbark:', totalBookmarkCount)
-  console.log('totalOotdCount:', totalOotdCount)
 
   return (
     <>
@@ -146,7 +139,7 @@ const MyPage = () => {
                 >
                   북마크
                 </span>
-                <span className="text-[#fa3463] ml-1">{totalBookmarkCount}</span>
+                <span className="text-[#fa3463] ml-1">{bookmarkCounts?.totalCount}</span>
               </button>
             </div>
           </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -84,9 +84,12 @@ const MyPage = () => {
         />
       </div>
       <div className="w-[66%] mx-auto">
-        <h1 className="w-[66%] absolute ml-auto text-right top-[320px] text-white text-4xl font-bold">
+        <h1 className="w-[66%] absolute ml-[240px] text-left top-[320px] text-white text-4xl font-bold">
           {userData && userData.blogName}
         </h1>
+        <div className="w-[66%] absolute ml-[240px] text-left top-[350px] text-white text-xl font-normal font-['Pretendard']">
+          {userData && userData.blogIntroduce}
+        </div>
       </div>
       <div className="w-[66%] mx-auto flex p-4">
         <div className="w-[250px] mb-4">

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -25,9 +25,10 @@ const TABS = {
 
 const UserPage = ({ params }: { params: { id: string } }) => {
   const { id } = params;
+  const decodedId = decodeURIComponent(params.id);
   const [activeTab, setActiveTab] = useState(() => {
 
-    const savedTab = sessionStorage.getItem(`activeTab_${id}`);
+    const savedTab = sessionStorage.getItem(`activeTab_${decodedId}`);
     return savedTab ? savedTab : TABS.TICKET;
   });
   const [userMeberId, setUserMemberId] = useState("");
@@ -46,14 +47,14 @@ const UserPage = ({ params }: { params: { id: string } }) => {
   }, []);
 
   const { data, error, isLoading, refetch } = useQuery({
-    queryKey: ["userProfile", id],
-    queryFn: () => fetchUserProfile(id),
+    queryKey: ["userProfile", decodedId],
+    queryFn: () => fetchUserProfile(decodedId),
     onError: (error) => {
       console.error(error);
     },
   });
 
-  console.log('유저정보', data);
+  console.log('유저아이디', decodedId);
 
   const emailData = data && data.result.email;
   const { data: userBoardCount } = useQuery({
@@ -63,14 +64,14 @@ const UserPage = ({ params }: { params: { id: string } }) => {
   });
 
   useEffect(() => {
-    if (id) {
+    if (decodedId) {
       refetch();
     }
-  }, [id, refetch]);
+  }, [decodedId, refetch]);
 
   useEffect(() => {
   
-    sessionStorage.setItem(`activeTab_${id}`, activeTab);
+    sessionStorage.setItem(`activeTab_${decodedId}`, activeTab);
   }, [activeTab, id]);
 
   if (isLoading) {
@@ -105,7 +106,7 @@ const UserPage = ({ params }: { params: { id: string } }) => {
       </div>
       <div className="w-[66%] mx-auto flex p-4">
         <div className="w-[250px] mb-4">
-          <UserProfile memberId={id} setActiveTab={setActiveTab} />
+          <UserProfile memberId={decodedId} setActiveTab={setActiveTab} />
         </div>
         <div className="w-[100%] ml-[50px]">
           <div className="flex justify-between mb-4 ml-4 text-2xl">
@@ -179,7 +180,7 @@ const UserPage = ({ params }: { params: { id: string } }) => {
                 memberEmail={memberEmail}
               />
             )}
-            {activeTab === TABS.OOTD && <UserOotd memberId={id} />}
+            {activeTab === TABS.OOTD && <UserOotd memberId={decodedId} />}
             {activeTab === TABS.BADGE && <UserBadge />}
             {activeTab === TABS.BOOKMARK && <UserBookmark />}
             {activeTab === TABS.FOLLOWER && (

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -53,6 +53,8 @@ const UserPage = ({ params }: { params: { id: string } }) => {
     },
   });
 
+  console.log('유저정보', data);
+
   const emailData = data && data.result.email;
   const { data: userBoardCount } = useQuery({
     queryKey: ["userBoardCount", emailData],
@@ -94,9 +96,12 @@ const UserPage = ({ params }: { params: { id: string } }) => {
         />
       </div>
       <div className="w-[66%] mx-auto">
-        <h1 className="w-[80%] absolute ml-auto text-right top-[320px] text-white text-4xl font-bold">
+      <h1 className="w-[66%] absolute ml-[240px] text-left top-[320px] text-white text-4xl font-bold">
           {userData && userData.blogName}
         </h1>
+        <div className="w-[66%] absolute ml-[240px] text-left top-[350px] text-white text-xl font-normal font-['Pretendard']">
+          {userData && userData.blogIntroduce}
+        </div>
       </div>
       <div className="w-[66%] mx-auto flex p-4">
         <div className="w-[250px] mb-4">

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -10,7 +10,7 @@ import UserBadge from "@/components/user/UserBadge";
 import UserBookmark from "@/components/user/UserBookmark";
 import Image from "next/image";
 import backgroundImg from "../../../../public/DefaultBackground.svg";
-import { fetchUserProfile } from "@/services/ootd.ts/ootdGet";
+import { fetchUserProfile, getUserTotalOotdCount } from "@/services/ootd.ts/ootdGet";
 import FollowList from "@/components/profile/FollowList";
 import { getUserTotalBoardCount } from "@/services/board/get/getBoard";
 
@@ -58,11 +58,19 @@ const UserPage = ({ params }: { params: { id: string } }) => {
   console.log('데이터', data);
 
   const emailData = data && data.result.email;
+
   const { data: userBoardCount } = useQuery({
     queryKey: ["userBoardCount", decodedId],
     queryFn: () => getUserTotalBoardCount(decodedId),
     enabled: !!data,
   });
+
+  const { data: userOotdCount } = useQuery({
+    queryKey: ["userOotdCount", decodedId],
+    queryFn: () => getUserTotalOotdCount(decodedId),
+    enabled: !!data,
+  });
+
 
   useEffect(() => {
     if (decodedId) {
@@ -139,6 +147,7 @@ const UserPage = ({ params }: { params: { id: string } }) => {
                 >
                   OOTD
                 </span>
+                 <span className="text-[#fa3463] ml-1">{userOotdCount}</span>
               </button>
               <button
                 className={`px-8 py-2 rounded-[999px] justify-center items-center ${

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -55,11 +55,12 @@ const UserPage = ({ params }: { params: { id: string } }) => {
   });
 
   console.log('유저아이디', decodedId);
+  console.log('데이터', data);
 
   const emailData = data && data.result.email;
   const { data: userBoardCount } = useQuery({
-    queryKey: ["userBoardCount", emailData],
-    queryFn: () => getUserTotalBoardCount(emailData),
+    queryKey: ["userBoardCount", decodedId],
+    queryFn: () => getUserTotalBoardCount(decodedId),
     enabled: !!data,
   });
 
@@ -177,7 +178,7 @@ const UserPage = ({ params }: { params: { id: string } }) => {
             {activeTab === TABS.TICKET && (
               <UserTicket
                 userBoardCount={userBoardCount}
-                memberEmail={memberEmail}
+                memberEmail={decodedId}
               />
             )}
             {activeTab === TABS.OOTD && <UserOotd memberId={decodedId} />}

--- a/src/app/user/[id]/page.tsx
+++ b/src/app/user/[id]/page.tsx
@@ -25,16 +25,17 @@ const TABS = {
 
 const UserPage = ({ params }: { params: { id: string } }) => {
   const { id } = params;
-  const [activeTab, setActiveTab] = useState(TABS.TICKET);
+  const [activeTab, setActiveTab] = useState(() => {
+
+    const savedTab = sessionStorage.getItem(`activeTab_${id}`);
+    return savedTab ? savedTab : TABS.TICKET;
+  });
   const [userMeberId, setUserMemberId] = useState("");
 
-  // Function to extract the user ID from the URL
   useEffect(() => {
     const extractUserId = () => {
       const currentUrl = window.location.href;
-
       const urlObj = new URL(currentUrl);
-
       const pathname = urlObj.pathname;
       const pathSegments = pathname.split("/");
       const userId = pathSegments[pathSegments.length - 1];
@@ -43,7 +44,6 @@ const UserPage = ({ params }: { params: { id: string } }) => {
 
     extractUserId();
   }, []);
-  console.log(userMeberId);
 
   const { data, error, isLoading, refetch } = useQuery({
     queryKey: ["userProfile", id],
@@ -59,29 +59,28 @@ const UserPage = ({ params }: { params: { id: string } }) => {
     queryFn: () => getUserTotalBoardCount(emailData),
     enabled: !!data,
   });
-  console.log(data);
-  console.log(userBoardCount);
 
-  console.log(id);
   useEffect(() => {
     if (id) {
       refetch();
     }
   }, [id, refetch]);
 
+  useEffect(() => {
+  
+    sessionStorage.setItem(`activeTab_${id}`, activeTab);
+  }, [activeTab, id]);
+
   if (isLoading) {
-    return <div>Loading...</div>;
+    return null;
   }
 
   if (error) {
-    return <div>Error</div>;
+    return null;
   }
 
   const userData = data && data.result;
-
-  console.log("userData: ", userData);
   const memberEmail = userData?.email;
-  console.log(memberEmail);
 
   return (
     <>
@@ -165,7 +164,6 @@ const UserPage = ({ params }: { params: { id: string } }) => {
                 </span>
               </button>
             </div>
-            <div className="flex space-x-4"></div>
           </div>
           <hr className="mb-4 w-full h-[1px]" />
 

--- a/src/components/ootd/OotdDetail.tsx
+++ b/src/components/ootd/OotdDetail.tsx
@@ -76,6 +76,7 @@ const OotdDetail: React.FC<OotdDetailProps> = ({ id }) => {
       if (ootdItem.member.memberId == userInfo.memberId) {
         router.push("/mypage");
       } else {
+        console.log(ootdItem.member.memberId);
         router.push(`/user/${ootdItem.member.memberId}`);
       }
     } else {

--- a/src/components/ootd/OotdDetail.tsx
+++ b/src/components/ootd/OotdDetail.tsx
@@ -200,7 +200,7 @@ const OotdDetail: React.FC<OotdDetailProps> = ({ id }) => {
                   alt="사용자 프로필"
                   layout="fill"
                   objectFit="cover"
-                  className="rounded-full"
+                  className="rounded-full cursor-pointer"
                   onClick={handleProfileClick}
                 />
               </div>

--- a/src/components/pages/ootd/CustomSelect.tsx
+++ b/src/components/pages/ootd/CustomSelect.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import Image from 'next/image';
+import UpIcon from '../../../../public/arrow_up.svg';
+import DownIcon from '../../../../public/arrow_down.svg';
+
+const CustomSelect: React.FC<{ orderType: string; onOrderTypeChange: (value: string) => void }> = ({
+  orderType,
+  onOrderTypeChange,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const options = [
+    { value: 'LATEST', label: '최신순' },
+    { value: 'LIKE', label: '인기순' },
+    { value: 'VIEW', label: '조회순' },
+  ];
+
+  const handleSelectOption = (value: string) => {
+    onOrderTypeChange(value);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative">
+      <div
+        className={`w-40 rounded-lg shadow-lg text-[#6b6b6b] text-base focus:outline-none cursor-pointer ${
+          isOpen ? 'border border-[#FB3463]' : ''
+        }`} 
+        style={{
+          borderRadius: "8px",
+          height: "3rem",
+          padding: "0.5rem 1rem",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {options.find(option => option.value === orderType)?.label}
+        {isOpen ? (
+          <Image src={UpIcon} alt="upIcon" width={16} height={28} />
+        ) : (
+          <Image src={DownIcon} alt="downIcon" width={16} height={28} />
+        )}
+      </div>
+
+      {isOpen && (
+        <div
+          className="absolute mt-1 w-full rounded-lg shadow-lg bg-white"
+          style={{ zIndex: 10 }}
+        >
+          {options.map(option => (
+            <div
+              key={option.value}
+              className="px-4 py-3 cursor-pointer hover:bg-neutral-100 text-[#6b6b6b] text-base"
+              onClick={() => handleSelectOption(option.value)}
+            >
+              {option.label}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CustomSelect;

--- a/src/components/pages/ootd/RecentOotdPost.tsx
+++ b/src/components/pages/ootd/RecentOotdPost.tsx
@@ -12,6 +12,7 @@ import EmptyHeartIcon from '../../../../public/empty_heart_default.svg';
 import CommentIcon1 from '../../../../public/empty_comment_default.svg';
 import { fetchLikedPosts } from '@/services/ootd.ts/ootdComments';
 import HeartIcon from '../../../../public/icon_heart.svg';
+import CustomSelect from './CustomSelect';
 
 const PAGE_SIZE = 12;
 
@@ -149,8 +150,8 @@ const RecentOotdPost: React.FC = () => {
     router.push(`/ootd/${id}`);
   };
 
-  const handleOrderTypeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    setOrderType(event.target.value);
+  const handleOrderTypeChange = (value: string) => {
+    setOrderType(value);
     setPage(0);
   };
 
@@ -189,15 +190,9 @@ const RecentOotdPost: React.FC = () => {
         >
           팔로잉
         </span>
-        <select
-          className='flex w-[8rem] h-[3rem] ml-auto font-medium selectshadow'
-          value={orderType}
-          onChange={handleOrderTypeChange}
-        >
-          <option value="LATEST">최신순</option>
-          <option value="LIKE">인기순</option>
-          <option value="VIEW">조회순</option>
-        </select>
+        <div className='ml-auto'>
+          <CustomSelect orderType={orderType} onOrderTypeChange={handleOrderTypeChange} />
+        </div>
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-8">
         {ootdList.map((item) => (

--- a/src/components/pages/ootd/RecentOotdPost.tsx
+++ b/src/components/pages/ootd/RecentOotdPost.tsx
@@ -57,9 +57,9 @@ const TagContainer: React.FC<TagContainerProps> = ({ item }) => {
 
   return (
     <div className="mt-4">
-       <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard'] text-ellipsis overflow-hidden whitespace-nowrap">
-              {item.post.body}
-            </div>
+      <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard'] text-ellipsis overflow-hidden whitespace-nowrap">
+        {item.post.body}
+      </div>
       <div className="tag-container mt-2" ref={containerRef}>
         {visibleTags.map((tag, index) => (
           <span
@@ -247,21 +247,19 @@ const RecentOotdPost: React.FC = () => {
           </div>
         ))}
       </div>
-      {totalPages > 1 && (
-        <div className='flex justify-center mt-4'>
-          {[...Array(totalPages)].map((_, index) => (
-            <button
-              key={index}
-              onClick={() => handlePageClick(index)}
-              className={`mx-2 py-16 px-3  ${
-                page === index ? 'text-[#fa3463] font-semibold' : 'text-[#cfcfcf] font-normal'
-              }`}
-            >
-              {index + 1}
-            </button>
-          ))}
-        </div>
-      )}
+      <div className='flex justify-center mt-4'>
+        {[...Array(totalPages)].map((_, index) => (
+          <button
+            key={index}
+            onClick={() => handlePageClick(index)}
+            className={`mx-2 py-16 px-3  ${
+              page === index ? 'text-[#fa3463] font-semibold' : 'text-[#cfcfcf] font-normal'
+            }`}
+          >
+            {index + 1}
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/components/profile/MyBookmark.tsx
+++ b/src/components/profile/MyBookmark.tsx
@@ -1,16 +1,28 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import Image from "next/image";
 import { fetchBookmarkedOotd, fetchBookmarkCount } from "@/services/bookmark/bookmark";
 import EmptyHeartIcon from '../../../public/empty_heart_default.svg';
 import CommentIcon1 from '../../../public/empty_comment_default.svg';
+import { fetchLikedPosts } from "@/services/ootd.ts/ootdComments";
+import Cookies from 'js-cookie';
+import HeartIcon from '../../../public/icon_heart.svg';
 
 
 const MyBookmark = () => {
   const [activeTab, setActiveTab] = useState("posts");
   const [pageOotd, setPageOotd] = useState(0); 
   const [totalOotdCount, setTotalOotdCount] = useState(0); 
+  const [likedPosts, setLikedPosts] = useState<number[]>([]);  
+  const accessToken = Cookies.get('accessToken');
   const PAGE_SIZE = 9;
+
+
+  useEffect(() => {
+    if (accessToken) {
+      fetchLikedPosts().then(setLikedPosts);  
+    }
+  }, [accessToken]);
 
   useQuery("bookmarkCount", fetchBookmarkCount, {
     onSuccess: (data) => {
@@ -101,7 +113,7 @@ const MyBookmark = () => {
                           </div>
                         </div>
                         <Image
-                          src={EmptyHeartIcon}
+                          src={likedPosts.includes(item.post.id) ? HeartIcon : EmptyHeartIcon} 
                           alt="좋아요"
                           width={20}
                           height={18}

--- a/src/components/profile/MyBookmark.tsx
+++ b/src/components/profile/MyBookmark.tsx
@@ -4,10 +4,12 @@ import Image from "next/image";
 import { fetchBookmarkedOotd, fetchBookmarkCount } from "@/services/bookmark/bookmark";
 import EmptyHeartIcon from '../../../public/empty_heart_default.svg';
 import CommentIcon1 from '../../../public/empty_comment_default.svg';
+import HeartIcon from '../../../public/icon_heart.svg';
 import { fetchLikedPosts } from "@/services/ootd.ts/ootdComments";
 import Cookies from 'js-cookie';
-import HeartIcon from '../../../public/icon_heart.svg';
+import { useRouter } from "next/navigation";
 
+const PAGE_SIZE = 9;
 
 const MyBookmark = () => {
   const [activeTab, setActiveTab] = useState("posts");
@@ -15,8 +17,7 @@ const MyBookmark = () => {
   const [totalOotdCount, setTotalOotdCount] = useState(0); 
   const [likedPosts, setLikedPosts] = useState<number[]>([]);  
   const accessToken = Cookies.get('accessToken');
-  const PAGE_SIZE = 9;
-
+  const router = useRouter();
 
   useEffect(() => {
     if (accessToken) {
@@ -40,6 +41,10 @@ const MyBookmark = () => {
 
   const handlePageClick = (pageIndex: number) => {
     setPageOotd(pageIndex);
+  };
+
+  const handlePostClick = (postId: number) => {
+    router.push(`/ootd/${postId}`); 
   };
 
   const renderPagination = (totalCount: number, currentPage: number) => {
@@ -89,7 +94,11 @@ const MyBookmark = () => {
               <>
                 <div className="grid grid-cols-3 gap-12">
                   {ootdData?.result?.map((item: any) => (
-                    <div key={item.ootd.id} className="flex-1 cursor-pointer">
+                    <div 
+                      key={item.ootd.id} 
+                      className="flex-1 cursor-pointer"
+                      onClick={() => handlePostClick(item.post.id)} 
+                    >
                       {item.post.images?.length > 0 && (
                         <div className="relative w-full pb-[100%]">
                           <Image

--- a/src/components/profile/MyBookmark.tsx
+++ b/src/components/profile/MyBookmark.tsx
@@ -1,9 +1,140 @@
-import React from "react";
+import React, { useState } from "react";
+import { useQuery } from "react-query";
+import Image from "next/image";
+import { fetchBookmarkedOotd, fetchBookmarkCount } from "@/services/bookmark/bookmark";
+import EmptyHeartIcon from '../../../public/empty_heart_default.svg';
+import CommentIcon1 from '../../../public/empty_comment_default.svg';
+
 
 const MyBookmark = () => {
+  const [activeTab, setActiveTab] = useState("posts");
+  const [pageOotd, setPageOotd] = useState(0); 
+  const [totalOotdCount, setTotalOotdCount] = useState(0); 
+  const PAGE_SIZE = 9;
+
+  const { data: bookmarkCounts } = useQuery("bookmarkCount", fetchBookmarkCount, {
+    onSuccess: (data) => {
+      setTotalOotdCount(data.ootdCount);
+    },
+  });
+
+  const { data: ootdData, isLoading: isOotdLoading } = useQuery(
+    ["bookmarkedOotd", pageOotd],
+    () => fetchBookmarkedOotd(pageOotd, PAGE_SIZE),
+    {
+      enabled: activeTab === "ootd" && totalOotdCount > 0,
+    }
+  );
+
+  const handlePageClick = (pageIndex: number) => {
+    setPageOotd(pageIndex);
+  };
+
+  const renderPagination = (totalCount: number, currentPage: number) => {
+    const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+    return (
+      <div className="flex justify-center my-16">
+        {Array.from({ length: totalPages }, (_, index) => (
+          <button
+            key={index}
+            onClick={() => handlePageClick(index)}
+            className={`mx-1 py-2 px-4 ${currentPage === index ? 'text-[#fa3463] font-semibold' : 'text-[#cfcfcf] font-normal'}`}
+          >
+            {index + 1}
+          </button>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <div className="h-[400px]">
-      <div className="flex flex-wrap gap-4">
+      <div className="flex border-b">
+        <button
+          className={`p-2 ${activeTab === "posts" ? "border-b-2 border-blue-500" : ""}`}
+          onClick={() => setActiveTab("posts")}
+        >
+          게시글
+        </button>
+        <button
+          className={`p-2 ${activeTab === "ootd" ? "border-b-2 border-blue-500" : ""}`}
+          onClick={() => setActiveTab("ootd")}
+        >
+          OOTD
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-4 mt-4">
+        {activeTab === "posts" && (
+          <div>게시글 탭의 내용이 여기에 표시됩니다.</div>
+        )}
+        {activeTab === "ootd" && (
+          <div className="h-full">
+            {isOotdLoading ? (
+              <p>Loading...</p>
+            ) : (
+              <>
+                <div className="grid grid-cols-3 gap-12">
+                  {ootdData?.result?.map((item: any) => (
+                    <div key={item.ootd.id} className="flex-1 cursor-pointer">
+                      {item.post.images?.length > 0 && (
+                        <div className="relative w-full pb-[100%]">
+                          <Image
+                            src={item.post.images[0].accessUri}
+                            alt="OOTD"
+                            className="absolute inset-0 w-full h-full object-cover rounded-lg"
+                            width={200}
+                            height={200}
+                          />
+                        </div>
+                      )}
+                      <div className="flex items-center my-4">
+                        <img
+                          src={item.member.profileUrl}
+                          alt="User Profile"
+                          className="w-10 h-10 rounded-full mr-2"
+                        />
+                        <div className="flex-1">
+                          <div className="text-[#6b6b6b] text-xl font-normal">
+                            {item.member.nickName}
+                          </div>
+                        </div>
+                        <Image
+                          src={EmptyHeartIcon}
+                          alt="좋아요"
+                          width={20}
+                          height={18}
+                        />
+                        <span className="mx-2 text-[#cfcfcf]">{item.post.likeCount}</span>
+                        <Image
+                          src={CommentIcon1}
+                          alt="댓글"
+                          width={18}
+                          height={18}
+                        />
+                        <span className="mx-2 text-[#cfcfcf]">{item.post.commentCount}</span>
+                      </div>
+                      <div className="text-[#6b6b6b] text-xl font-normal text-ellipsis overflow-hidden whitespace-nowrap">
+                        {item.post.body}
+                      </div>
+                      <div className="tag-container">
+                        {item.post.tags?.map((tag: string, index: number) => (
+                          <span
+                            key={index}
+                            className="tag-item px-4 py-1 bg-neutral-100 rounded-3xl text-xl text-[#9d9d9d]"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                {renderPagination(totalOotdCount, pageOotd)}
+              </>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/profile/MyBookmark.tsx
+++ b/src/components/profile/MyBookmark.tsx
@@ -12,7 +12,7 @@ const MyBookmark = () => {
   const [totalOotdCount, setTotalOotdCount] = useState(0); 
   const PAGE_SIZE = 9;
 
-  const { data: bookmarkCounts } = useQuery("bookmarkCount", fetchBookmarkCount, {
+  useQuery("bookmarkCount", fetchBookmarkCount, {
     onSuccess: (data) => {
       setTotalOotdCount(data.ootdCount);
     },
@@ -49,15 +49,15 @@ const MyBookmark = () => {
 
   return (
     <div className="h-[400px]">
-      <div className="flex border-b">
+      <div className="flex">
         <button
-          className={`p-2 ${activeTab === "posts" ? "border-b-2 border-blue-500" : ""}`}
+          className={`p-2 text-2xl ${activeTab === "posts" ? "text-[#fa3463] font-semibold" : ""}`}
           onClick={() => setActiveTab("posts")}
         >
           게시글
         </button>
         <button
-          className={`p-2 ${activeTab === "ootd" ? "border-b-2 border-blue-500" : ""}`}
+          className={`ml-[10px] p-2 text-2xl ${activeTab === "ootd" ? "text-[#fa3463] font-semibold" : ""}`}
           onClick={() => setActiveTab("ootd")}
         >
           OOTD
@@ -66,12 +66,13 @@ const MyBookmark = () => {
 
       <div className="flex flex-wrap gap-4 mt-4">
         {activeTab === "posts" && (
-          <div>게시글 탭의 내용이 여기에 표시됩니다.</div>
+          // todo: bookmark 한 게시글 post 레이아웃 영역 //
+          <></>
         )}
         {activeTab === "ootd" && (
           <div className="h-full">
             {isOotdLoading ? (
-              <p>Loading...</p>
+              <></>
             ) : (
               <>
                 <div className="grid grid-cols-3 gap-12">

--- a/src/components/profile/MyOotd.tsx
+++ b/src/components/profile/MyOotd.tsx
@@ -1,51 +1,38 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "react-query";
-import { fetchOotdPostCount, fetchOotdPosts } from "@/services/ootd.ts/ootdGet";
-import Cookies from "js-cookie";
-import { UserInfoType } from "@/types/auth";
+import { fetchUserOotdPosts } from "@/services/ootd.ts/ootdGet";
 import { OotdGetResponse } from "@/types/ootd";
 import EmptyHeartIcon from '../../../public/empty_heart_default.svg';
 import CommentIcon1 from '../../../public/empty_comment_default.svg';
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import HeartIcon from '../../../public/icon_heart.svg';
+import Cookies from "js-cookie";
 import { fetchLikedPosts } from "@/services/ootd.ts/ootdComments";
 
 const PAGE_SIZE = 9;
 
-interface MyOotdProps {
-  userInfo: UserInfoType;
+interface UserOotdProps {
+  memberId: string;
 }
 
-const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
-  const [page, setPage] = React.useState(0);
-  const [likedPosts, setLikedPosts] = useState<number[]>([]);  
+const UserOotd: React.FC<UserOotdProps> = ({ memberId }) => {
+  const [likedPosts, setLikedPosts] = useState<number[]>([]);
 
   const accessToken = Cookies.get('accessToken');
 
   useEffect(() => {
     if (accessToken) {
-      fetchLikedPosts().then(setLikedPosts);  
+      fetchLikedPosts().then(setLikedPosts);
     }
   }, [accessToken]);
 
-  const { data: totalCount, isLoading: isCountLoading, isError: isCountError } = useQuery<number>(
-    'ootdPostCount',
-    fetchOotdPostCount,
-    { enabled: !!accessToken }
-  );
-  
+  // 첫 번째 페이지의 OOTD 게시물 가져오기
   const { data, isLoading, isError } = useQuery<OotdGetResponse>(
-    ['ootdPosts', page],
-    () => fetchOotdPosts(page, PAGE_SIZE),
-    { enabled: !!totalCount }
+    ['userOotdPosts', memberId],
+    () => fetchUserOotdPosts(memberId, 0, PAGE_SIZE),
+    { enabled: !!memberId }
   );
-
-  const totalPages = totalCount ? Math.ceil(totalCount / PAGE_SIZE) : 0;
-
-  const handlePageClick = (pageIndex: number) => {
-    setPage(pageIndex);
-  };
 
   const router = useRouter();
 
@@ -53,12 +40,12 @@ const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
     router.push(`/ootd/${id}`);
   };
 
-  if (isCountLoading || isLoading) {
-    return null;
+  if (isLoading) {
+    return <div>Loading...</div>;
   }
 
-  if (isCountError || isError || !data) {
-    return null;
+  if (isError || !data) {
+    return <div>Error fetching OOTD posts</div>;
   }
 
   const ootdList = data.result;
@@ -67,7 +54,11 @@ const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
     <div className="h-full">
       <div className="grid grid-cols-3 gap-12">
         {ootdList.map((item) => (
-          <div key={item.ootd.id} className="flex-1 cursor-pointer" onClick={() => handleOotdItemClick(item.post.id)}>
+          <div
+            key={item.ootd.id}
+            className="flex-1 cursor-pointer"
+            onClick={() => handleOotdItemClick(item.post.id)}
+          >
             {item.post.images.length > 0 && (
               <div className="relative w-full pb-[100%]">
                 <Image
@@ -81,15 +72,17 @@ const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
             )}
             <div className="flex items-center my-4">
               <img
-                src={userInfo.profileImageUrl}
+                src={item.member.profileUrl}
                 alt="User Profile"
                 className="w-10 h-10 rounded-full mr-2"
               />
               <div className="flex-1">
-                <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard']">{item.member.nickName}</div>
+                <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard']">
+                  {item.member.nickName}
+                </div>
               </div>
               <Image
-                src={likedPosts.includes(item.post.id) ? HeartIcon : EmptyHeartIcon} 
+                src={likedPosts.includes(item.post.id) ? HeartIcon : EmptyHeartIcon}
                 alt="좋아요"
                 width={20}
                 height={18}
@@ -119,19 +112,8 @@ const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
           </div>
         ))}
       </div>
-      <div className="flex justify-center my-16">
-        {Array.from({ length: totalPages }, (_, index) => (
-          <button
-            key={index}
-            onClick={() => handlePageClick(index)}
-            className={`mx-1 py-2 px-4 ${page === index ? 'text-[#fa3463] font-semibold' : 'text-[#cfcfcf] font-normal'}`}
-          >
-            {index + 1}
-          </button>
-        ))}
-      </div>
     </div>
   );
 };
 
-export default MyOotd;
+export default UserOotd;

--- a/src/components/profile/MyOotd.tsx
+++ b/src/components/profile/MyOotd.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { fetchOotdPostCount, fetchOotdPosts } from "@/services/ootd.ts/ootdGet";
 import Cookies from "js-cookie";
@@ -8,6 +8,8 @@ import EmptyHeartIcon from '../../../public/empty_heart_default.svg';
 import CommentIcon1 from '../../../public/empty_comment_default.svg';
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import HeartIcon from '../../../public/icon_heart.svg';
+import { fetchLikedPosts } from "@/services/ootd.ts/ootdComments";
 
 const PAGE_SIZE = 9;
 
@@ -17,8 +19,15 @@ interface MyOotdProps {
 
 const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
   const [page, setPage] = React.useState(0);
+  const [likedPosts, setLikedPosts] = useState<number[]>([]);  
 
   const accessToken = Cookies.get('accessToken');
+
+  useEffect(() => {
+    if (accessToken) {
+      fetchLikedPosts().then(setLikedPosts);  
+    }
+  }, [accessToken]);
 
   const { data: totalCount, isLoading: isCountLoading, isError: isCountError } = useQuery<number>(
     'ootdPostCount',
@@ -80,7 +89,7 @@ const MyOotd: React.FC<MyOotdProps> = ({ userInfo }) => {
                 <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard']">{item.member.nickName}</div>
               </div>
               <Image
-                src={EmptyHeartIcon}
+                src={likedPosts.includes(item.post.id) ? HeartIcon : EmptyHeartIcon} 
                 alt="좋아요"
                 width={20}
                 height={18}

--- a/src/components/profile/UserInformation.tsx
+++ b/src/components/profile/UserInformation.tsx
@@ -50,7 +50,7 @@ const UserInformation: React.FC<{ setActiveTab: (tab: string) => void }> = ({
   return (
     <div className="w-full flex flex-col relative">
       <div className="w-[80%]">
-        <div className="absolute top-[-150px] w-[200px] h-auto bg-white px-8 py-4 rounded-lg shadow-lg flex flex-col items-center">
+        <div className="absolute top-[-150px] w-[200px] h-auto bg-white px-8 py-6 rounded-lg shadow-lg flex flex-col items-center">
           <div className="relative my-4">
             <Image
               src={userData?.profileImageUrl}
@@ -76,22 +76,18 @@ const UserInformation: React.FC<{ setActiveTab: (tab: string) => void }> = ({
             {userData?.email}
           </span>
           <div className="mt-[10px] flex px-4">
-            <span
-              className="text-sm text-gray-600 cursor-pointer"
-              onClick={() => setActiveTab(TABS.FOLLOWER)}
-            >
-              팔로워 {userData?.followerCnt}
+            <span className="text-base text-[#9d9d9d] cursor-pointer" onClick={() => setActiveTab(TABS.FOLLOWER)}>
+              팔로워 
+              <span className="text-[#6b6b6b]"> {userData?.followerCnt}</span>
             </span>
-            <span className="text-sm text-gray-600">&ensp;|&ensp;</span>
-            <span
-              className="text-sm text-gray-600 cursor-pointer"
-              onClick={() => setActiveTab(TABS.FOLLOWING)}
-            >
-              팔로윙 {userData?.followingCnt}
+            <span className="text-base text-[#9d9d9d]">&ensp;|&ensp;</span>
+            <span className="text-base text-[#9d9d9d] cursor-pointer" onClick={() => setActiveTab(TABS.FOLLOWING)}>
+              팔로잉 
+              <span className="text-[#6b6b6b]"> {userData?.followingCnt}</span>
             </span>
           </div>
           <button
-            className="mt-[10px] pl-[20px] pr-[20px] py-2 bg-btn-color text-white rounded-lg justify-center items-center inline-flex ]"
+            className="w-full mt-[10px] pl-[20px] pr-[20px] py-[7px] text-base border border-[#cfcfcf] text-[#6b6b6b] rounded-2xl justify-center items-center inline-flex"
             onClick={handleEditProfile}
           >
             내 정보 수정
@@ -102,9 +98,7 @@ const UserInformation: React.FC<{ setActiveTab: (tab: string) => void }> = ({
           >
             팔로우
           </button> */}
-          <span className="mt-[10px] text-sm text-gray-600">
-            {userData?.blogIntroduce}
-          </span>
+          
         </div>
       </div>
     </div>

--- a/src/components/user/UserOotd.tsx
+++ b/src/components/user/UserOotd.tsx
@@ -1,48 +1,113 @@
-import React from 'react';
-import { useQuery } from 'react-query';
-import { fetchUserOotdPosts } from '@/services/ootd.ts/ootdGet';
-import { OotdGetResponse } from '@/types/ootd';
-import { formatDate } from '@/constants/dateFotmat';
+import React, { useEffect, useState } from "react";
+import { useQuery } from "react-query";
+import { fetchUserOotdPosts } from "@/services/ootd.ts/ootdGet";
+import { OotdGetResponse } from "@/types/ootd";
+import EmptyHeartIcon from '../../../public/empty_heart_default.svg';
+import CommentIcon1 from '../../../public/empty_comment_default.svg';
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import HeartIcon from '../../../public/icon_heart.svg';
+import Cookies from "js-cookie";
+import { fetchLikedPosts } from "@/services/ootd.ts/ootdComments";
+
+const PAGE_SIZE = 9;
 
 interface UserOotdProps {
   memberId: string;
 }
 
 const UserOotd: React.FC<UserOotdProps> = ({ memberId }) => {
+  const [likedPosts, setLikedPosts] = useState<number[]>([]);
 
-  console.log('Member ID:', memberId);
-  
-  const { data, isLoading, error } = useQuery<OotdGetResponse>(
-    ['userOotdPosts', memberId],
-    () => fetchUserOotdPosts(memberId, 0, 9),
-    {
-      staleTime: Infinity,
-      cacheTime: Infinity,
+  const accessToken = Cookies.get('accessToken');
+
+  useEffect(() => {
+    if (accessToken) {
+      fetchLikedPosts().then(setLikedPosts);
     }
+  }, [accessToken]);
+
+  // 첫 번째 페이지의 OOTD 게시물 가져오기
+  const { data, isLoading, isError } = useQuery<OotdGetResponse>(
+    ['userOotdPosts', memberId],
+    () => fetchUserOotdPosts(memberId, 0, PAGE_SIZE),
+    { enabled: !!memberId }
   );
 
-  if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error fetching OOTD posts</div>;
-  if (!data) return <div>No data</div>;
+  const router = useRouter();
+
+  const handleOotdItemClick = (id: number) => {
+    router.push(`/ootd/${id}`);
+  };
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (isError || !data) {
+    return <div>Error fetching OOTD posts</div>;
+  }
 
   const ootdList = data.result;
 
   return (
-    <div>
-      <div className="grid grid-cols-3 gap-4">
+    <div className="h-full">
+      <div className="grid grid-cols-3 gap-12">
         {ootdList.map((item) => (
-          <div key={item.post.id} className="border p-4 rounded-lg">
+          <div
+            key={item.ootd.id}
+            className="flex-1 cursor-pointer"
+            onClick={() => handleOotdItemClick(item.post.id)}
+          >
             {item.post.images.length > 0 && (
-              <img
-                src={item.post.images[0].accessUri}
-                alt="OOTD"
-                className="w-full h-auto rounded-lg"
-              />
+              <div className="relative w-full pb-[100%]">
+                <Image
+                  src={item.post.images[0].accessUri}
+                  alt="OOTD"
+                  className="absolute inset-0 w-full h-full object-cover rounded-lg"
+                  width={200}
+                  height={200}
+                />
+              </div>
             )}
-            <div className="mt-2">
-              <div className="text-gray-600">{item.post.nickName}</div>
-              <div className="text-gray-400">{formatDate(item.post.createDateTime)}</div>
-              <p>{item.post.body}</p>
+            <div className="flex items-center my-4">
+              <img
+                src={item.member.profileUrl}
+                alt="User Profile"
+                className="w-10 h-10 rounded-full mr-2"
+              />
+              <div className="flex-1">
+                <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard']">
+                  {item.member.nickName}
+                </div>
+              </div>
+              <Image
+                src={likedPosts.includes(item.post.id) ? HeartIcon : EmptyHeartIcon}
+                alt="좋아요"
+                width={20}
+                height={18}
+              />
+              <span className="mx-2 text-[#cfcfcf]"> {item.post.likeCount}</span>
+              <Image
+                src={CommentIcon1}
+                alt="댓글"
+                width={18}
+                height={18}
+              />
+              <span className="mx-2 text-[#cfcfcf]"> {item.post.commentCount}</span>
+            </div>
+            <div className="text-[#6b6b6b] text-xl font-normal font-['Pretendard'] text-ellipsis overflow-hidden whitespace-nowrap">
+              {item.post.body}
+            </div>
+            <div className="tag-container">
+              {item.post.tags.map((tag: string, index: number) => (
+                <span
+                  key={index}
+                  className="tag-item px-4 py-1 bg-neutral-100 rounded-3xl text-xl text-[#9d9d9d]"
+                >
+                  {tag}
+                </span>
+              ))}
             </div>
           </div>
         ))}
@@ -52,4 +117,3 @@ const UserOotd: React.FC<UserOotdProps> = ({ memberId }) => {
 };
 
 export default UserOotd;
-

--- a/src/components/user/UserOotd.tsx
+++ b/src/components/user/UserOotd.tsx
@@ -9,6 +9,9 @@ interface UserOotdProps {
 }
 
 const UserOotd: React.FC<UserOotdProps> = ({ memberId }) => {
+
+  console.log('Member ID:', memberId);
+  
   const { data, isLoading, error } = useQuery<OotdGetResponse>(
     ['userOotdPosts', memberId],
     () => fetchUserOotdPosts(memberId, 0, 9),

--- a/src/components/user/UserOotd.tsx
+++ b/src/components/user/UserOotd.tsx
@@ -34,6 +34,7 @@ const UserOotd: React.FC<UserOotdProps> = ({ memberId }) => {
     { enabled: !!memberId }
   );
 
+
   const { data, isLoading, isError } = useQuery<OotdGetResponse>(
     ['userOotdPosts', memberId, page],
     () => fetchUserOotdPosts(memberId, page, PAGE_SIZE),  

--- a/src/components/user/UserProfile.tsx
+++ b/src/components/user/UserProfile.tsx
@@ -69,20 +69,17 @@ const UserProfile: React.FC<UserProfileProps> = ({
           <h1 className="text-4xl font-bold mt-[10px]">{nickName}</h1>
           <span className="text-xl text-gray-600 mt-[5px]">{email}</span>
           <div className="mt-[10px] flex px-4">
-            <span
-              className="text-sm text-gray-600 cursor-pointer"
-              onClick={() => setActiveTab(TABS.FOLLOWER)}
-            >
-              팔로워 {followerCnt}
+            <span className="text-base text-[#9d9d9d] cursor-pointer" onClick={() => setActiveTab(TABS.FOLLOWER)}>
+              팔로워 
+              <span className="text-[#6b6b6b]"> {followerCnt}</span>
             </span>
-            <span className="text-sm text-gray-600">&ensp;|&ensp;</span>
-            <span
-              className="text-sm text-gray-600 cursor-pointer"
-              onClick={() => setActiveTab(TABS.FOLLOWING)}
-            >
-              팔로잉 {followingCnt}
+            <span className="text-base text-[#9d9d9d]">&ensp;|&ensp;</span>
+            <span className="text-base text-[#9d9d9d] cursor-pointer" onClick={() => setActiveTab(TABS.FOLLOWING)}>
+              팔로잉 
+              <span className="text-[#6b6b6b]"> {followingCnt}</span>
             </span>
           </div>
+
           <div className="ml-auto flex items-center mt-[10px] mr-[50px]">
             {targetMemberId &&
               userMemberId && ( // Check both IDs are available
@@ -92,10 +89,6 @@ const UserProfile: React.FC<UserProfileProps> = ({
                 />
               )}
           </div>
-
-          <span className="mt-[10px] text-sm text-gray-600">
-            {blogIntroduce}
-          </span>
         </div>
       </div>
     </div>

--- a/src/services/bookmark/bookmark.ts
+++ b/src/services/bookmark/bookmark.ts
@@ -3,18 +3,24 @@ import { bookmarkCount } from '@/types/bookmark';
 const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 
-export const fetchBookmarkCount = async (): Promise<number> => {
-    try {
-      const response = await axios.get<{ result: { totalCount: number; postCount: number; ootdCount: number } }>(
-        `${backendUrl}/api/bookmark/count/my`
-      );
-      console.log(response.data);
-      return response.data.result.totalCount;
-    } catch (error) {
-      console.error(`전체 북마크 데이터 개수를 가져오는 중 오류가 발생했습니다: ${error}`);
-      throw error;
-    }
-  };
+export interface BookmarkCounts {
+  totalCount: number;
+  postCount: number;
+  ootdCount: number;
+}
+
+export const fetchBookmarkCount = async (): Promise<BookmarkCounts> => {
+  try {
+    const response = await axios.get<{ result: BookmarkCounts }>(
+      `${backendUrl}/api/bookmark/count/my`
+    );
+    return response.data.result;
+  } catch (error) {
+    console.error(`북마크 데이터를 가져오는 중 오류가 발생했습니다: ${error}`);
+    throw error;
+  }
+};
+
 
   export const fetchIsBookmarked = async (postId: number): Promise<boolean> => {
     try {
@@ -45,3 +51,18 @@ export const fetchBookmarkCount = async (): Promise<number> => {
       throw error;
     }
   };
+
+
+  export const fetchBookmarkedOotd = async (page = 0, size = 9) => {
+    const response = await axios.get(`${backendUrl}/api/bookmark`, {
+      params: {
+        orderType: "LATEST",  
+        postType: "OOTD",     
+        page,                 
+        size,                
+      },
+    });
+  
+    return response.data;
+  };
+  

--- a/src/services/ootd.ts/ootdGet.ts
+++ b/src/services/ootd.ts/ootdGet.ts
@@ -114,13 +114,13 @@ export const fetchUserOotdPosts = async (memberId: string, page: number, size: n
       memberId
     },
   });
-  console.log('유저 정보 api: ', response);
   return response.data;
 };
 
-export const fetchUserProfile = (memberId: string) => {
-  console.log('유저 아이디:',memberId);
-  return axios.get(`${backendUrl}/api/member/profile?memberId=${memberId}`).then((res) => res.data);
+export const fetchUserProfile = async (memberId: string) => {
+  const response = await axios.get(`${backendUrl}/api/member/profile?memberId=${memberId}`);
+  console.log('유저정보 api: ', response)
+  return response.data;
 };
 
 export const updatePost = async (id: number, postRequest: PostRequest) => {

--- a/src/services/ootd.ts/ootdGet.ts
+++ b/src/services/ootd.ts/ootdGet.ts
@@ -187,7 +187,7 @@ export const fetchOotdFollowPostCount = async (): Promise<number> => {
   }
 };
 
-export const getUserTotalOOtdCount = async (memberId: string): Promise<number> => {
+export const getUserTotalOotdCount = async (memberId: string): Promise<number> => {
   try {
       const response = await axios.get<{ result: number }>(
           `${backendUrl}/api/post/count/by-member?type=OOTD&memberId=${memberId}`

--- a/src/services/ootd.ts/ootdGet.ts
+++ b/src/services/ootd.ts/ootdGet.ts
@@ -186,3 +186,15 @@ export const fetchOotdFollowPostCount = async (): Promise<number> => {
     throw error;
   }
 };
+
+export const getUserTotalOOtdCount = async (memberId: string): Promise<number> => {
+  try {
+      const response = await axios.get<{ result: number }>(
+          `${backendUrl}/api/post/count/by-member?type=OOTD&memberId=${memberId}`
+      );
+      return response.data.result;
+  } catch (error) {
+      console.error(`전체 OOTD 데이터 개수를 가져오는 중 오류가 발생했습니다: ${error}`);
+      throw error;
+  }
+};

--- a/src/services/ootd.ts/ootdGet.ts
+++ b/src/services/ootd.ts/ootdGet.ts
@@ -107,14 +107,21 @@ export const fetchFollowOotdPosts = async (page: number, size: number, orderType
   return response.data;
 };
 
-
-export const fetchUserOotdPosts = async (memberId: string, page: number, size: number) => {
-  const response = await axios.get(`${backendUrl}/api/ootd/by-member`, {
-    params: {
-      memberId
-    },
-  });
-  return response.data;
+export const fetchUserOotdPosts = async (memberId: string, page: number, size: number): Promise<OotdGetResponse> => {
+  try {
+    const response = await axios.get<OotdGetResponse>(`${backendUrl}/api/ootd/by-member`, {
+      params: {
+        memberId,
+        page,
+        size,
+        orderType: 'LATEST',
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error(`Error fetching user OOTD posts: ${error}`);
+    throw error;
+  }
 };
 
 export const fetchUserProfile = async (memberId: string) => {

--- a/src/services/ootd.ts/ootdGet.ts
+++ b/src/services/ootd.ts/ootdGet.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { OotdDetailGetResponse, OotdGetResponse, OotdRequest, PostRequest } from '@/types/ootd';
 import Cookies from "js-cookie";
 
+
 const backendUrl: string = process.env.NEXT_PUBLIC_BACKEND_URL || '';
 
 export const fetchOotdPostCount = async (): Promise<number> => {
@@ -113,10 +114,12 @@ export const fetchUserOotdPosts = async (memberId: string, page: number, size: n
       memberId
     },
   });
+  console.log('유저 정보 api: ', response);
   return response.data;
 };
 
 export const fetchUserProfile = (memberId: string) => {
+  console.log('유저 아이디:',memberId);
   return axios.get(`${backendUrl}/api/member/profile?memberId=${memberId}`).then((res) => res.data);
 };
 

--- a/src/types/bookmark.ts
+++ b/src/types/bookmark.ts
@@ -8,3 +8,9 @@ export interface bookmarkCount {
 	    ootdCount : number;
     }
 }
+
+export interface BookmarkCounts {
+    totalCount: number;
+    postCount: number;
+    ootdCount: number;
+  }


### PR DESCRIPTION
close #111 

- 북마크한 ootd api 연동
- 마이페이지 레이아웃 및 bookmark 영역 디자인
- myootd, mybookbark 탭에서 좋아요 누른 게시글 아이콘 렌더링
- 북마크탭에서 ootd 게시글 클릭 시, ootd 상세페이지 이동
- 마이페이지 탭 상태 session Storage 관리
- 유저페이지 유저별 탭 상태 session Storage 관리
- 유저페이지 레이아웃 디자인
- 유저페이지 userId params로 가져올 때 이메일 인코딩되는 문제
- 유저 ootd 개수 반환 api 연동 및 페이지네이션 구현
- 유저페이지 post 게시글 props memberId로 변경
- ootd 페이지 팔로잉 탭 페이지 1개일 때도 숫자 렌더링
- ootd 페이지 토글 섹션 디자인